### PR TITLE
Fixed typo: \scriptS -- \mathcal{S}

### DIFF
--- a/src/main.tex
+++ b/src/main.tex
@@ -356,7 +356,7 @@ $\mathcal{X} \subset \mathbb{R}^D$であり、$\mathbf{x}_n \in \mathbb{R}^D$で
 厳密に扱われないようです。
 
 パワーポイント中で集合を表現するには、数式機能中で\mintinline{tex}{\scriptS}のようにします。
-これはTeX中の\mintinline{tex}{\mathrm{S}}に対応します。
+これはTeX中の\mintinline{tex}{\mathcal{S}}に対応します。
 
 
 \subsection{例}


### PR DESCRIPTION
Since the LaTeX code in `\scriptS` was `\mathrm{S}`, I've corrected it to `\mathcal{S}`.